### PR TITLE
Update Dart Code link

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,6 @@ Flutter snippets for vscode translated from IntelliJ IDEA Official Snippets
 
 I'll try to keep the repository updated with the latest snippets published by the flutter team for VSCODE,
 
-Use this in combination with the [Dart Code](https://marketplace.visualstudio.com/items?itemName=DanTup.dart-code) extension and the terminal and you have a complete environment to work with.
+Use this in combination with the [Dart Code](https://marketplace.visualstudio.com/items?itemName=Dart-Code.dart-code) extension and the terminal and you have a complete environment to work with.
 
 Pull Requests Apreciated.


### PR DESCRIPTION
The URL for Dart Code changed a few weeks back.

Though it's worth noting that Dart Code now includes Flutter widgets out-of-the-box! :)